### PR TITLE
Implement symbol assignment (NL!Core 11.1 feature port)

### DIFF
--- a/ColorzCore/Lexer/TokenType.cs
+++ b/ColorzCore/Lexer/TokenType.cs
@@ -17,6 +17,7 @@ namespace ColorzCore.Lexer
         OPEN_PAREN,
         CLOSE_PAREN,
         COMMA,
+        EQUALS_OP,
         MUL_OP,
         DIV_OP,
         MOD_OP,

--- a/ColorzCore/Lexer/Tokenizer.cs
+++ b/ColorzCore/Lexer/Tokenizer.cs
@@ -122,6 +122,9 @@ namespace ColorzCore.Lexer
                     case ',':
                         yield return new Token(TokenType.COMMA, fileName, lineNum, curCol+offset);
                         break;
+                    case '=':
+                        yield return new Token(TokenType.EQUALS_OP, fileName, lineNum, curCol+offset);
+                        break;
                     case '/':
                         if (curCol + 1 < endOffs && line[curCol + 1] == '/')
                         {

--- a/ColorzCore/Parser/AST/AtomNodeKernel.cs
+++ b/ColorzCore/Parser/AST/AtomNodeKernel.cs
@@ -51,6 +51,6 @@ namespace ColorzCore.Parser.AST
         }
         public abstract bool CanEvaluate();
         public abstract IAtomNode Simplify();
-        public abstract bool DependsOnSymbol(string name);
+        public abstract bool EvaluationRequiresName(string name);
     }
 }

--- a/ColorzCore/Parser/AST/AtomNodeKernel.cs
+++ b/ColorzCore/Parser/AST/AtomNodeKernel.cs
@@ -51,5 +51,6 @@ namespace ColorzCore.Parser.AST
         }
         public abstract bool CanEvaluate();
         public abstract IAtomNode Simplify();
+        public abstract bool DependsOnSymbol(string name);
     }
 }

--- a/ColorzCore/Parser/AST/IAtomNode.cs
+++ b/ColorzCore/Parser/AST/IAtomNode.cs
@@ -17,6 +17,6 @@ namespace ColorzCore.Parser.AST
         IEnumerable<Token> ToTokens();
         bool CanEvaluate();
         IAtomNode Simplify();
-        bool EvaluationRequiresName(string name);
+        bool DependsOnSymbol(string name);
     }
 }

--- a/ColorzCore/Parser/AST/IAtomNode.cs
+++ b/ColorzCore/Parser/AST/IAtomNode.cs
@@ -17,6 +17,6 @@ namespace ColorzCore.Parser.AST
         IEnumerable<Token> ToTokens();
         bool CanEvaluate();
         IAtomNode Simplify();
-        bool DependsOnSymbol(string name);
+        bool EvaluationRequiresName(string name);
     }
 }

--- a/ColorzCore/Parser/AST/IAtomNode.cs
+++ b/ColorzCore/Parser/AST/IAtomNode.cs
@@ -17,5 +17,6 @@ namespace ColorzCore.Parser.AST
         IEnumerable<Token> ToTokens();
         bool CanEvaluate();
         IAtomNode Simplify();
+        bool DependsOnSymbol(string name);
     }
 }

--- a/ColorzCore/Parser/AST/IdentifierNode.cs
+++ b/ColorzCore/Parser/AST/IdentifierNode.cs
@@ -25,8 +25,8 @@ namespace ColorzCore.Parser.AST
             ImmutableStack<Closure> temp = scope;
             while(!temp.IsEmpty)
             {
-                if(temp.Head.HasLocalLabel(identifier.Content))
-                    return temp.Head.GetLabel(identifier.Content);
+                if(temp.Head.HasLocalSymbolValue(identifier.Content))
+                    return temp.Head.GetSymbolValue(identifier.Content);
                 else
                     temp = temp.Tail;
             }
@@ -68,7 +68,7 @@ namespace ColorzCore.Parser.AST
 
         public override bool CanEvaluate()
         {
-            return Enumerable.Any(scope, (Closure c) => c.HasLocalLabel(identifier.Content));
+            return Enumerable.Any(scope, (Closure c) => c.HasLocalSymbolValue(identifier.Content));
         }
 
         public override IAtomNode Simplify()
@@ -88,7 +88,7 @@ namespace ColorzCore.Parser.AST
 
             while (!temp.IsEmpty)
             {
-                if (temp.Head.CouldHaveLocalLabel(identifier.Content))
+                if (temp.Head.HasLocalSymbol(identifier.Content))
                     return true;
 
                 temp = temp.Tail;

--- a/ColorzCore/Parser/AST/IdentifierNode.cs
+++ b/ColorzCore/Parser/AST/IdentifierNode.cs
@@ -88,7 +88,7 @@ namespace ColorzCore.Parser.AST
 
             while (!temp.IsEmpty)
             {
-                if (temp.Head.HasLocalSymbol(identifier.Content))
+                if (temp.Head.EvaluationRequiresName(identifier.Content, name))
                     return true;
 
                 temp = temp.Tail;

--- a/ColorzCore/Parser/AST/IdentifierNode.cs
+++ b/ColorzCore/Parser/AST/IdentifierNode.cs
@@ -79,7 +79,7 @@ namespace ColorzCore.Parser.AST
                 return new NumberNode(identifier, Evaluate());
         }
 
-        public override bool DependsOnSymbol(string name)
+        public override bool EvaluationRequiresName(string name)
         {
             if (identifier.Content == name)
                 return true;

--- a/ColorzCore/Parser/AST/IdentifierNode.cs
+++ b/ColorzCore/Parser/AST/IdentifierNode.cs
@@ -79,5 +79,22 @@ namespace ColorzCore.Parser.AST
                 return new NumberNode(identifier, Evaluate());
         }
 
+        public override bool DependsOnSymbol(string name)
+        {
+            if (identifier.Content == name)
+                return true;
+
+            ImmutableStack<Closure> temp = scope;
+
+            while (!temp.IsEmpty)
+            {
+                if (temp.Head.CouldHaveLocalLabel(identifier.Content))
+                    return true;
+
+                temp = temp.Tail;
+            }
+
+            return false;
+        }
     }
 }

--- a/ColorzCore/Parser/AST/NegationNode.cs
+++ b/ColorzCore/Parser/AST/NegationNode.cs
@@ -52,7 +52,7 @@ namespace ColorzCore.Parser.AST
 
         public override bool DependsOnSymbol(string name)
         {
-            return interior.EvaluationRequiresName(name);
+            return interior.DependsOnSymbol(name);
         }
 
         public override IEnumerable<Token> ToTokens()

--- a/ColorzCore/Parser/AST/NegationNode.cs
+++ b/ColorzCore/Parser/AST/NegationNode.cs
@@ -50,6 +50,11 @@ namespace ColorzCore.Parser.AST
             }
         }
 
+        public override bool DependsOnSymbol(string name)
+        {
+            return interior.DependsOnSymbol(name);
+        }
+
         public override IEnumerable<Token> ToTokens()
         {
             yield return myToken;

--- a/ColorzCore/Parser/AST/NegationNode.cs
+++ b/ColorzCore/Parser/AST/NegationNode.cs
@@ -52,7 +52,7 @@ namespace ColorzCore.Parser.AST
 
         public override bool DependsOnSymbol(string name)
         {
-            return interior.DependsOnSymbol(name);
+            return interior.EvaluationRequiresName(name);
         }
 
         public override IEnumerable<Token> ToTokens()

--- a/ColorzCore/Parser/AST/NegationNode.cs
+++ b/ColorzCore/Parser/AST/NegationNode.cs
@@ -50,9 +50,9 @@ namespace ColorzCore.Parser.AST
             }
         }
 
-        public override bool DependsOnSymbol(string name)
+        public override bool EvaluationRequiresName(string name)
         {
-            return interior.DependsOnSymbol(name);
+            return interior.EvaluationRequiresName(name);
         }
 
         public override IEnumerable<Token> ToTokens()

--- a/ColorzCore/Parser/AST/NumberNode.cs
+++ b/ColorzCore/Parser/AST/NumberNode.cs
@@ -47,5 +47,10 @@ namespace ColorzCore.Parser.AST
         {
             return this;
         }
+
+        public override bool DependsOnSymbol(string name)
+        {
+            return false;
+        }
     }
 }

--- a/ColorzCore/Parser/AST/NumberNode.cs
+++ b/ColorzCore/Parser/AST/NumberNode.cs
@@ -48,7 +48,7 @@ namespace ColorzCore.Parser.AST
             return this;
         }
 
-        public override bool DependsOnSymbol(string name)
+        public override bool EvaluationRequiresName(string name)
         {
             return false;
         }

--- a/ColorzCore/Parser/AST/OperatorNode.cs
+++ b/ColorzCore/Parser/AST/OperatorNode.cs
@@ -115,9 +115,9 @@ namespace ColorzCore.Parser.AST
                 return this;
         }
 
-        public override bool DependsOnSymbol(string name)
+        public override bool EvaluationRequiresName(string name)
         {
-            return left.DependsOnSymbol(name) || right.DependsOnSymbol(name);
+            return left.EvaluationRequiresName(name) || right.EvaluationRequiresName(name);
         }
     }
 }

--- a/ColorzCore/Parser/AST/OperatorNode.cs
+++ b/ColorzCore/Parser/AST/OperatorNode.cs
@@ -117,7 +117,7 @@ namespace ColorzCore.Parser.AST
 
         public override bool DependsOnSymbol(string name)
         {
-            return left.DependsOnSymbol(name) || right.DependsOnSymbol(name);
+            return left.EvaluationRequiresName(name) || right.EvaluationRequiresName(name);
         }
     }
 }

--- a/ColorzCore/Parser/AST/OperatorNode.cs
+++ b/ColorzCore/Parser/AST/OperatorNode.cs
@@ -117,7 +117,7 @@ namespace ColorzCore.Parser.AST
 
         public override bool DependsOnSymbol(string name)
         {
-            return left.EvaluationRequiresName(name) || right.EvaluationRequiresName(name);
+            return left.DependsOnSymbol(name) || right.DependsOnSymbol(name);
         }
     }
 }

--- a/ColorzCore/Parser/AST/OperatorNode.cs
+++ b/ColorzCore/Parser/AST/OperatorNode.cs
@@ -114,5 +114,10 @@ namespace ColorzCore.Parser.AST
             else
                 return this;
         }
+
+        public override bool DependsOnSymbol(string name)
+        {
+            return left.DependsOnSymbol(name) || right.DependsOnSymbol(name);
+        }
     }
 }

--- a/ColorzCore/Parser/AST/ParenthesizedAtomNode.cs
+++ b/ColorzCore/Parser/AST/ParenthesizedAtomNode.cs
@@ -70,9 +70,9 @@ namespace ColorzCore.Parser.AST
             }
         }
 
-        public override bool DependsOnSymbol(string name)
+        public override bool EvaluationRequiresName(string name)
         {
-            return inner.DependsOnSymbol(name);
+            return inner.EvaluationRequiresName(name);
         }
     }
 }

--- a/ColorzCore/Parser/AST/ParenthesizedAtomNode.cs
+++ b/ColorzCore/Parser/AST/ParenthesizedAtomNode.cs
@@ -69,5 +69,10 @@ namespace ColorzCore.Parser.AST
                 return this;
             }
         }
+
+        public override bool DependsOnSymbol(string name)
+        {
+            return inner.DependsOnSymbol(name);
+        }
     }
 }

--- a/ColorzCore/Parser/AST/ParenthesizedAtomNode.cs
+++ b/ColorzCore/Parser/AST/ParenthesizedAtomNode.cs
@@ -72,7 +72,7 @@ namespace ColorzCore.Parser.AST
 
         public override bool DependsOnSymbol(string name)
         {
-            return inner.EvaluationRequiresName(name);
+            return inner.DependsOnSymbol(name);
         }
     }
 }

--- a/ColorzCore/Parser/AST/ParenthesizedAtomNode.cs
+++ b/ColorzCore/Parser/AST/ParenthesizedAtomNode.cs
@@ -72,7 +72,7 @@ namespace ColorzCore.Parser.AST
 
         public override bool DependsOnSymbol(string name)
         {
-            return inner.DependsOnSymbol(name);
+            return inner.EvaluationRequiresName(name);
         }
     }
 }

--- a/ColorzCore/Parser/BaseClosure.cs
+++ b/ColorzCore/Parser/BaseClosure.cs
@@ -7,9 +7,9 @@
         {
             this.enclosing = enclosing;
         }
-        public override bool HasLocalLabel(string label)
+        public override bool HasLocalSymbolValue(string label)
         {
-            return label.ToUpper() == "CURRENTOFFSET" || base.HasLocalLabel(label);
+            return label.ToUpper() == "CURRENTOFFSET" || base.HasLocalSymbolValue(label);
         }
     }
 }

--- a/ColorzCore/Parser/Closure.cs
+++ b/ColorzCore/Parser/Closure.cs
@@ -13,6 +13,10 @@ namespace ColorzCore.Parser
             Symbols = new Dictionary<string, int>();
             NonComputedSymbols = new Dictionary<string, IAtomNode>();
         }
+        public virtual bool CouldHaveLocalLabel(string label)
+        {
+            return Symbols.ContainsKey(label) || NonComputedSymbols.ContainsKey(label);
+        }
         public virtual bool HasLocalLabel(string label)
         {
             if (Symbols.ContainsKey(label))

--- a/ColorzCore/Parser/Closure.cs
+++ b/ColorzCore/Parser/Closure.cs
@@ -13,11 +13,11 @@ namespace ColorzCore.Parser
             Symbols = new Dictionary<string, int>();
             NonComputedSymbols = new Dictionary<string, IAtomNode>();
         }
-        public virtual bool CouldHaveLocalLabel(string label)
+        public virtual bool HasLocalSymbol(string label)
         {
             return Symbols.ContainsKey(label) || NonComputedSymbols.ContainsKey(label);
         }
-        public virtual bool HasLocalLabel(string label)
+        public virtual bool HasLocalSymbolValue(string label)
         {
             if (Symbols.ContainsKey(label))
                 return true;
@@ -29,7 +29,7 @@ namespace ColorzCore.Parser
 
             return node.CanEvaluate();
         }
-        public virtual int GetLabel(string label)
+        public virtual int GetSymbolValue(string label)
         {
             int value;
 
@@ -46,16 +46,16 @@ namespace ColorzCore.Parser
 
             return value;
         }
-        public void AddLabel(string label, int value)
+        public void AddSymbol(string label, int value)
         {
             Symbols[label] = value;
         }
         public void AddSymbol(string label, IAtomNode node)
         {
             if (node.CanEvaluate())
-                AddLabel(label, node.Evaluate());
+                AddSymbol(label, node.Evaluate());
 
-            NonComputedSymbols[label] = node;
+            NonComputedSymbols[label] = node.Simplify();
         }
     }
 }

--- a/ColorzCore/Parser/Closure.cs
+++ b/ColorzCore/Parser/Closure.cs
@@ -1,26 +1,57 @@
 ﻿using System.Collections.Generic;
+using ColorzCore.Parser.AST;
 
 namespace ColorzCore.Parser
 {
     public class Closure
     {
-        private Dictionary<string, int> Labels { get; }
+        private Dictionary<string, int> Symbols { get; }
+        private Dictionary<string, IAtomNode> NonComputedSymbols { get; }
 
         public Closure()
         {
-            Labels = new Dictionary<string, int>();
+            Symbols = new Dictionary<string, int>();
+            NonComputedSymbols = new Dictionary<string, IAtomNode>();
         }
         public virtual bool HasLocalLabel(string label)
         {
-            return Labels.ContainsKey(label);
+            if (Symbols.ContainsKey(label))
+                return true;
+
+            IAtomNode node;
+
+            if (!NonComputedSymbols.TryGetValue(label, out node))
+                return false;
+
+            return node.CanEvaluate();
         }
         public virtual int GetLabel(string label)
         {
-            return Labels[label];
+            int value;
+
+            if (Symbols.TryGetValue(label, out value))
+                return value;
+            
+            // To allow for better performance, we only ever evaluate assigned symbols once
+
+            IAtomNode node = NonComputedSymbols[label];
+            NonComputedSymbols.Remove(label);
+
+            value = node.Evaluate();
+            Symbols[label] = value;
+
+            return value;
         }
         public void AddLabel(string label, int value)
         {
-            Labels[label] = value;
+            Symbols[label] = value;
+        }
+        public void AddSymbol(string label, IAtomNode node)
+        {
+            if (node.CanEvaluate())
+                AddLabel(label, node.Evaluate());
+
+            NonComputedSymbols[label] = node;
         }
     }
 }

--- a/ColorzCore/Parser/Closure.cs
+++ b/ColorzCore/Parser/Closure.cs
@@ -52,9 +52,6 @@ namespace ColorzCore.Parser
         }
         public void AddSymbol(string label, IAtomNode node)
         {
-            if (node.CanEvaluate())
-                AddSymbol(label, node.Evaluate());
-
             NonComputedSymbols[label] = node.Simplify();
         }
     }

--- a/ColorzCore/Parser/Closure.cs
+++ b/ColorzCore/Parser/Closure.cs
@@ -29,6 +29,18 @@ namespace ColorzCore.Parser
 
             return node.CanEvaluate();
         }
+        public virtual bool EvaluationRequiresName(string label, string other)
+        {
+            if (Symbols.ContainsKey(label))
+                return true;
+
+            IAtomNode node;
+
+            if (!NonComputedSymbols.TryGetValue(label, out node))
+                return false;
+
+            return node.EvaluationRequiresName(other);
+        }
         public virtual int GetSymbolValue(string label)
         {
             int value;

--- a/ColorzCore/Parser/EAParser.cs
+++ b/ColorzCore/Parser/EAParser.cs
@@ -631,7 +631,7 @@ namespace ColorzCore.Parser
                             if (tokens.Current.Type == TokenType.COLON)
                             {
                                 tokens.MoveNext();
-                                if (scopes.Head.HasLocalLabel(head.Content))
+                                if (scopes.Head.HasLocalSymbol(head.Content))
                                 {
                                     Warning(head.Location, "Symbol already in scope, ignoring: " + head.Content);//replacing: " + head.Content);
                                 }
@@ -641,7 +641,7 @@ namespace ColorzCore.Parser
                                 }
                                 else
                                 {
-                                    scopes.Head.AddLabel(head.Content, CurrentOffset);
+                                    scopes.Head.AddSymbol(head.Content, CurrentOffset);
                                 }
 
                                 return new Nothing<ILineNode>();
@@ -652,7 +652,7 @@ namespace ColorzCore.Parser
 
                                 // TODO: avoid duplicate code with the label part above?
 
-                                if (scopes.Head.HasLocalLabel(head.Content))
+                                if (scopes.Head.HasLocalSymbol(head.Content))
                                 {
                                     Warning(head.Location, "Symbol already in scope, ignoring: " + head.Content);
                                 }

--- a/ColorzCore/Parser/EAParser.cs
+++ b/ColorzCore/Parser/EAParser.cs
@@ -672,7 +672,7 @@ namespace ColorzCore.Parser
                                     {
                                         IAtomNode node = maybe.FromJust;
 
-                                        if (node.DependsOnSymbol(head.Content))
+                                        if (node.EvaluationRequiresName(head.Content))
                                         {
                                             Error(head.Location, "Assigned symbol depends on itself! ");
                                         }

--- a/ColorzCore/Parser/EAParser.cs
+++ b/ColorzCore/Parser/EAParser.cs
@@ -633,15 +633,45 @@ namespace ColorzCore.Parser
                                 tokens.MoveNext();
                                 if (scopes.Head.HasLocalLabel(head.Content))
                                 {
-                                    Warning(head.Location, "Label already in scope, ignoring: " + head.Content);//replacing: " + head.Content);
+                                    Warning(head.Location, "Symbol already in scope, ignoring: " + head.Content);//replacing: " + head.Content);
                                 }
-                                else if(!IsValidLabelName(head.Content))
+                                else if (!IsValidLabelName(head.Content))
                                 {
                                     Error(head.Location, "Invalid label name " + head.Content + '.');
                                 }
                                 else
                                 {
                                     scopes.Head.AddLabel(head.Content, CurrentOffset);
+                                }
+
+                                return new Nothing<ILineNode>();
+                            }
+                            else if (tokens.Current.Type == TokenType.EQUALS_OP)
+                            {
+                                tokens.MoveNext();
+
+                                // TODO: avoid duplicate code with the label part above?
+
+                                if (scopes.Head.HasLocalLabel(head.Content))
+                                {
+                                    Warning(head.Location, "Symbol already in scope, ignoring: " + head.Content);
+                                }
+                                else if (!IsValidLabelName(head.Content))
+                                {
+                                    Error(head.Location, "Invalid label name " + head.Content + '.');
+                                }
+                                else
+                                {
+                                    Maybe<IAtomNode> node = ParseAtom(tokens, scopes);
+
+                                    if (node.IsNothing)
+                                    {
+                                        Error(head.Location, "Expected expression for symbol assignment. ");
+                                    }
+                                    else
+                                    {
+                                        scopes.Head.AddSymbol(head.Content, node.FromJust);
+                                    }
                                 }
 
                                 return new Nothing<ILineNode>();

--- a/ColorzCore/Parser/EAParser.cs
+++ b/ColorzCore/Parser/EAParser.cs
@@ -662,15 +662,24 @@ namespace ColorzCore.Parser
                                 }
                                 else
                                 {
-                                    Maybe<IAtomNode> node = ParseAtom(tokens, scopes);
+                                    Maybe<IAtomNode> maybe = ParseAtom(tokens, scopes);
 
-                                    if (node.IsNothing)
+                                    if (maybe.IsNothing)
                                     {
                                         Error(head.Location, "Expected expression for symbol assignment. ");
                                     }
                                     else
                                     {
-                                        scopes.Head.AddSymbol(head.Content, node.FromJust);
+                                        IAtomNode node = maybe.FromJust;
+
+                                        if (node.DependsOnSymbol(head.Content))
+                                        {
+                                            Error(head.Location, "Assigned symbol depends on itself! ");
+                                        }
+                                        else
+                                        {
+                                            scopes.Head.AddSymbol(head.Content, node);
+                                        }
                                     }
                                 }
 

--- a/ColorzCore/Parser/EAParser.cs
+++ b/ColorzCore/Parser/EAParser.cs
@@ -672,7 +672,11 @@ namespace ColorzCore.Parser
                                     {
                                         IAtomNode node = maybe.FromJust;
 
-                                        if (node.EvaluationRequiresName(head.Content))
+                                        if (node.CanEvaluate())
+                                        {
+                                            scopes.Head.AddSymbol(head.Content, node.Evaluate());
+                                        }
+                                        else if (node.EvaluationRequiresName(head.Content))
                                         {
                                             Error(head.Location, "Assigned symbol depends on itself! ");
                                         }


### PR DESCRIPTION
    <Name> = <Expression>

Thanks to ColorzCore's internal improvements, this implementation of the feature shouldn't freak out when assigning symbols to expressions invoking `CURRENTOFFSET` while not being immediately computable (because of `CURRENTOFFSET` now being substituted at parse-time (?)).

Another improvement over the 11.1 impl is that circular dependencies are detected and diagnosed. For example, the following:

    A = B
    B = C
    C = A

Will print this error:

    In File Main.event, Line 3, Column 1: Assigned symbol depends on itself!

---

Some files seem to have been detected as having completely been rewritten... is this caused by a difference in encoding?

~~Hopefully I didn't taint your code of my incompetence *too* much.~~ (but do tell me if I did)