### PR TITLE
Add AST traversal to simplify expressions and track undefined IDs.

### DIFF
--- a/ColorzCore/Parser/AST/AtomNodeKernel.cs
+++ b/ColorzCore/Parser/AST/AtomNodeKernel.cs
@@ -12,13 +12,13 @@ namespace ColorzCore.Parser.AST
     {
         public abstract int Precedence { get; }
 
-        public abstract int Evaluate();
+        public abstract int ToInt();
 
         public ParamType Type { get { return ParamType.ATOM; } }
 
         public override string ToString()
         {
-            return "0x"+Evaluate().ToString("X");
+            return "0x"+ToInt().ToString("X");
         }
 
         public virtual Maybe<string> GetIdentifier()
@@ -37,7 +37,7 @@ namespace ColorzCore.Parser.AST
         {
             try
             {
-                int res = this.Evaluate();
+                int res = this.ToInt();
                 return new Left<int, string>(res);
             }
             catch (IdentifierNode.UndefinedIdentifierException e)
@@ -50,6 +50,14 @@ namespace ColorzCore.Parser.AST
             }
         }
         public abstract bool CanEvaluate();
+
+        public abstract Maybe<int> Evaluate(ICollection<Token> undefinedIdentifiers);
+        
+        Maybe<IParamNode> IParamNode.Evaluate(ICollection<Token> undefinedIdentifiers)
+        {
+            return Evaluate(undefinedIdentifiers).Fmap((int a) => (IParamNode)new NumberNode(MyLocation, a));
+        }
+
         public abstract IAtomNode Simplify();
     }
 }

--- a/ColorzCore/Parser/AST/BlockNode.cs
+++ b/ColorzCore/Parser/AST/BlockNode.cs
@@ -1,5 +1,6 @@
 ﻿using ColorzCore.DataTypes;
 using ColorzCore.IO;
+using ColorzCore.Lexer;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -45,6 +46,12 @@ namespace ColorzCore.Parser.AST
             {
                 child.WriteData(rom);
             }
+        }
+
+        public void EvaluateExpressions(ICollection<Token> undefinedIdentifiers)
+        {
+            foreach (ILineNode line in Children)
+                line.EvaluateExpressions(undefinedIdentifiers);
         }
     }
 }

--- a/ColorzCore/Parser/AST/DataNode.cs
+++ b/ColorzCore/Parser/AST/DataNode.cs
@@ -1,4 +1,5 @@
 ﻿using ColorzCore.IO;
+using ColorzCore.Lexer;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,6 +29,11 @@ namespace ColorzCore.Parser.AST
         public void WriteData(ROM rom)
         {
             rom.WriteTo(offset, data);
+        }
+
+        public void EvaluateExpressions(ICollection<Token> undefinedIdentifiers)
+        { 
+            // Nothing to be done because we contain no expressions.
         }
     }
 }

--- a/ColorzCore/Parser/AST/IAtomNode.cs
+++ b/ColorzCore/Parser/AST/IAtomNode.cs
@@ -12,10 +12,11 @@ namespace ColorzCore.Parser.AST
     {
         //TODO: Simplify() partial evaluation as much as is defined, to save on memory space.
 		int Precedence { get; }
-		int Evaluate(); //May throw errors. TODO: Remove and only do calls through TryEvaluate?
+		int ToInt(); //May throw errors. TODO: Remove and only do calls through TryEvaluate?
         Maybe<string> GetIdentifier();
         IEnumerable<Token> ToTokens();
         bool CanEvaluate();
         IAtomNode Simplify();
+        new Maybe<int> Evaluate(ICollection<Token> undefinedIdentifiers);
     }
 }

--- a/ColorzCore/Parser/AST/ILineNode.cs
+++ b/ColorzCore/Parser/AST/ILineNode.cs
@@ -1,4 +1,5 @@
 ﻿using ColorzCore.IO;
+using ColorzCore.Lexer;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,5 +13,6 @@ namespace ColorzCore.Parser.AST
         int Size { get; }
         string PrettyPrint(int indentation);
         void WriteData(ROM rom);
+        void EvaluateExpressions(ICollection<Token> undefinedIdentifiers); //Return: undefined identifiers
     }
 }

--- a/ColorzCore/Parser/AST/IParamNode.cs
+++ b/ColorzCore/Parser/AST/IParamNode.cs
@@ -14,6 +14,7 @@ namespace ColorzCore.Parser.AST
         ParamType Type { get; }
         string PrettyPrint();
         Location MyLocation { get; }
+        Maybe<IParamNode> Evaluate(ICollection<Token> unidentifiedIdentifiers);
 
         Either<int, string> TryEvaluate();
     }

--- a/ColorzCore/Parser/AST/IdentifierNode.cs
+++ b/ColorzCore/Parser/AST/IdentifierNode.cs
@@ -9,7 +9,7 @@ namespace ColorzCore.Parser.AST
     public class IdentifierNode : AtomNodeKernel
     {
         private Token identifier;
-        ImmutableStack<Closure> scope;
+        readonly ImmutableStack<Closure> scope;
 
 		public override int Precedence { get { return 11; } }
         public override Location MyLocation { get { return identifier.Location; } }
@@ -20,7 +20,7 @@ namespace ColorzCore.Parser.AST
             scope = scopes;
 		}
 		
-		public override int Evaluate()
+		public override int ToInt()
         {
             ImmutableStack<Closure> temp = scope;
             while(!temp.IsEmpty)
@@ -32,6 +32,18 @@ namespace ColorzCore.Parser.AST
             }
             throw new UndefinedIdentifierException(identifier);
         }
+
+        public override Maybe<int> Evaluate(ICollection<Token> undefinedIdentifiers)
+        {
+            try
+            {
+                return new Just<int>(ToInt());
+            } catch(UndefinedIdentifierException e)
+            {
+                undefinedIdentifiers.Add(e.CausedError);
+                return new Nothing<int>();
+            }
+        }
         
         public override Maybe<string> GetIdentifier()
         {
@@ -42,7 +54,7 @@ namespace ColorzCore.Parser.AST
         {
             try
             {
-                return "0x"+Evaluate().ToString("X");
+                return "0x"+ToInt().ToString("X");
             }
             catch (UndefinedIdentifierException)
             {
@@ -76,7 +88,7 @@ namespace ColorzCore.Parser.AST
             if (!CanEvaluate())
                 return this;
             else
-                return new NumberNode(identifier, Evaluate());
+                return new NumberNode(identifier, ToInt());
         }
 
     }

--- a/ColorzCore/Parser/AST/ListNode.cs
+++ b/ColorzCore/Parser/AST/ListNode.cs
@@ -27,7 +27,7 @@ namespace ColorzCore.Parser.AST
             sb.Append('[');
             for(int i=0; i<Interior.Count; i++)
             {
-                sb.Append(Interior[i].Evaluate());
+                sb.Append(Interior[i].ToInt());
                 if(i < Interior.Count - 1)
                     sb.Append(',');
             }
@@ -77,6 +77,16 @@ namespace ColorzCore.Parser.AST
         public Either<int, string> TryEvaluate()
         {
             return new Right<int, string>("Expected atomic parameter.");
+        }
+
+        public Maybe<IParamNode> Evaluate(ICollection<Token> undefinedIdentifiers)
+        {
+            IEnumerable<Token> acc = new List<Token>();
+            for(int i=0; i<Interior.Count; i++)
+            {
+                Interior[i].Evaluate(undefinedIdentifiers).IfJust((int a) => { Interior[i] = new NumberNode(Interior[i].MyLocation, a); });
+            }
+            return new Just<IParamNode>(this);
         }
 
         public int NumCoords { get { return Interior.Count; } }

--- a/ColorzCore/Parser/AST/MacroInvocationNode.cs
+++ b/ColorzCore/Parser/AST/MacroInvocationNode.cs
@@ -10,6 +10,15 @@ namespace ColorzCore.Parser.AST
 {
     class MacroInvocationNode : IParamNode
     {
+        public class MacroException : Exception
+        {
+            public MacroInvocationNode CausedError { get; private set; }
+            public MacroException(MacroInvocationNode min)
+            {
+                CausedError = min;
+            }
+        }
+
         private EAParser p;
         private Token invokeToken;
         public IList<IList<Token>> Parameters { get; }
@@ -54,5 +63,11 @@ namespace ColorzCore.Parser.AST
         public string Name { get { return invokeToken.Content; } }
 
         public Location MyLocation { get { return invokeToken.Location; } }
+
+        public Maybe<IParamNode> Evaluate(ICollection<Token> undefinedIdentifiers)
+        {
+            //There shouldn't be macros lingering out by the time we're simplifying?
+            throw new MacroException(this);
+        }
     }
 }

--- a/ColorzCore/Parser/AST/NegationNode.cs
+++ b/ColorzCore/Parser/AST/NegationNode.cs
@@ -27,9 +27,9 @@ namespace ColorzCore.Parser.AST
             return interior.CanEvaluate();
         }
 
-        public override int Evaluate()
+        public override int ToInt()
         {
-            return -interior.Evaluate();
+            return -interior.ToInt();
         }
 
         public override string PrettyPrint()
@@ -42,7 +42,7 @@ namespace ColorzCore.Parser.AST
             interior = interior.Simplify();
             if(CanEvaluate())
             {
-                return new NumberNode(MyLocation, Evaluate());
+                return new NumberNode(MyLocation, ToInt());
             }
             else
             {
@@ -55,6 +55,11 @@ namespace ColorzCore.Parser.AST
             yield return myToken;
             foreach(Token t in interior.ToTokens())
                 yield return t;
+        }
+
+        public override Maybe<int> Evaluate(ICollection<Token> undefinedIdentifiers)
+        {
+            return interior.Evaluate(undefinedIdentifiers).Fmap((int x) => -x);
         }
     }
 }

--- a/ColorzCore/Parser/AST/NumberNode.cs
+++ b/ColorzCore/Parser/AST/NumberNode.cs
@@ -31,7 +31,7 @@ namespace ColorzCore.Parser.AST
             this.value = value;
         }
 
-        public override int Evaluate()
+        public override int ToInt()
         {
             return value;
         }
@@ -46,6 +46,11 @@ namespace ColorzCore.Parser.AST
         public override IAtomNode Simplify()
         {
             return this;
+        }
+
+        public override Maybe<int> Evaluate(ICollection<Token> undefinedIdentifiers)
+        {
+            return new Just<int>(value);
         }
     }
 }

--- a/ColorzCore/Parser/AST/OperatorNode.cs
+++ b/ColorzCore/Parser/AST/OperatorNode.cs
@@ -41,9 +41,9 @@ namespace ColorzCore.Parser.AST
             Precedence = prec;
 		}
 		
-		public override int Evaluate()
+		public override int ToInt()
 		{
-            return Operators[op.Type](left.Evaluate(), right.Evaluate());
+            return Operators[op.Type](left.ToInt(), right.ToInt());
 		}
 
         public override string PrettyPrint()
@@ -110,9 +110,16 @@ namespace ColorzCore.Parser.AST
             left = left.Simplify();
             right = right.Simplify();
             if (CanEvaluate())
-                return new NumberNode(left.MyLocation, Evaluate());
+                return new NumberNode(left.MyLocation, ToInt());
             else
                 return this;
+        }
+
+        public override Maybe<int> Evaluate(ICollection<Token> undefinedIdentifiers)
+        {
+            Maybe<int> l = left.Evaluate(undefinedIdentifiers);
+            Maybe<int> r = right.Evaluate(undefinedIdentifiers);
+            return l.Bind<int>((int newL) => r.Fmap((int newR) => Operators[op.Type](newL, newR)));
         }
     }
 }

--- a/ColorzCore/Parser/AST/ParenthesizedAtomNode.cs
+++ b/ColorzCore/Parser/AST/ParenthesizedAtomNode.cs
@@ -22,9 +22,9 @@ namespace ColorzCore.Parser.AST
             inner = putIn;
         }
 
-        public override int Evaluate()
+        public override int ToInt()
         {
-            return inner.Evaluate();
+            return inner.ToInt();
         }
 
         public override Maybe<string> GetIdentifier()
@@ -63,11 +63,16 @@ namespace ColorzCore.Parser.AST
             inner = inner.Simplify();
             if(CanEvaluate())
             {
-                return new NumberNode(MyLocation, Evaluate());
+                return new NumberNode(MyLocation, ToInt());
             } else
             {
                 return this;
             }
+        }
+
+        public override Maybe<int> Evaluate(ICollection<Token> undefinedIdentifiers)
+        {
+            return inner.Evaluate(undefinedIdentifiers);
         }
     }
 }

--- a/ColorzCore/Parser/AST/StatementNode.cs
+++ b/ColorzCore/Parser/AST/StatementNode.cs
@@ -33,5 +33,11 @@ namespace ColorzCore.Parser.AST
                 }
             }
         }
+
+        public void EvaluateExpressions(ICollection<Token> undefinedIdentifiers)
+        {
+            for (int i = 0; i < Parameters.Count; i++)
+                Parameters[i].Evaluate(undefinedIdentifiers).IfJust((IParamNode p) => { Parameters[i] = p; });
+        }
     }
 }

--- a/ColorzCore/Parser/AST/StringNode.cs
+++ b/ColorzCore/Parser/AST/StringNode.cs
@@ -50,5 +50,10 @@ namespace ColorzCore.Parser.AST
         {
             return new IdentifierNode(MyToken, scope);
         }
+        public Maybe<IParamNode> Evaluate(ICollection<Token> undefinedIds)
+        {
+            //Nothing to be done.
+            return new Just<IParamNode>(this);
+        }
     }
 }

--- a/ColorzCore/Raws/AtomicParam.cs
+++ b/ColorzCore/Raws/AtomicParam.cs
@@ -29,7 +29,7 @@ namespace ColorzCore.Raws
 
         public void Set(BitArray data, IParamNode input)
         {
-            Set(data, ((IAtomNode)input).Evaluate());
+            Set(data, ((IAtomNode)input).ToInt());
         }
         public void Set(BitArray data, int res)
         {

--- a/ColorzCore/Raws/ListParam.cs
+++ b/ColorzCore/Raws/ListParam.cs
@@ -32,7 +32,7 @@ namespace ColorzCore.Raws
             int bitsPerAtom = Length / numCoords;
             foreach(IAtomNode a in interior)
             {
-                int res = a.Evaluate();
+                int res = a.ToInt();
                 for(int i=0; i<bitsPerAtom; i++, res >>= 1)
                 {
                     data[i + Position + count] = (res & 1) == 1;


### PR DESCRIPTION
Addresses #7 

TODO: remove other simplication/toInt passes as they're redundant. (#23)