### PR TITLE
exit 1 on failure & no$gba-compatible sym output

### DIFF
--- a/ColorzCore/EAInterpreter.cs
+++ b/ColorzCore/EAInterpreter.cs
@@ -150,7 +150,8 @@ namespace ColorzCore
 
             foreach (var label in myParser.GlobalScope.Head.LocalLabels())
             {
-                output.WriteLine("{0:X8} {1}", label.Value, label.Key);
+                // TODO: more elegant offset to address mapping
+                output.WriteLine("{0:X8} {1}", label.Value + 0x8000000, label.Key);
             }
 
             return true;

--- a/ColorzCore/EAInterpreter.cs
+++ b/ColorzCore/EAInterpreter.cs
@@ -141,6 +141,21 @@ namespace ColorzCore
             }
         }
 
+        public bool WriteNocashSymbols(TextWriter output)
+        {
+            if (myParser == null)
+            {
+                return false;
+            }
+
+            foreach (var label in myParser.GlobalScope.Head.LocalLabels())
+            {
+                output.WriteLine("{0:X8} {1}", label.Value, label.Key);
+            }
+
+            return true;
+        }
+
         private static IList<Raw> LoadAllRaws(string rawsFolder, string rawsExtension)
         {
             string folder;

--- a/ColorzCore/EAInterpreter.cs
+++ b/ColorzCore/EAInterpreter.cs
@@ -44,7 +44,7 @@ namespace ColorzCore
             this.opts = opts;
         }
 
-        public void Interpret()
+        public bool Interpret()
         {
             myParser = new EAParser(allRaws);
             myParser.Definitions['_' + game + '_'] = new Definition();
@@ -130,11 +130,14 @@ namespace ColorzCore
                     }
                     line.WriteData(myROM);
                 }
+
                 myROM.WriteROM();
+                return true;
             }
             else
             {
                 serr.WriteLine("Errors occurred; no changes written.");
+                return false;
             }
         }
 

--- a/ColorzCore/EAOptions.cs
+++ b/ColorzCore/EAOptions.cs
@@ -11,11 +11,14 @@ namespace ColorzCore
         public bool werr;
         public bool nowarn, nomess;
 
+        public bool nocashSym;
+
         public EAOptions()
         {
             werr = false;
             nowarn = false;
             nomess = false;
+            nocashSym = false;
         }
     }
 }

--- a/ColorzCore/Parser/Closure.cs
+++ b/ColorzCore/Parser/Closure.cs
@@ -22,5 +22,13 @@ namespace ColorzCore.Parser
         {
             Labels[label] = value;
         }
+
+        public IEnumerable<KeyValuePair<string, int>> LocalLabels()
+        {
+            foreach (KeyValuePair<string, int> label in Labels)
+            {
+                yield return label;
+            }
+        }
     }
 }

--- a/ColorzCore/Program.cs
+++ b/ColorzCore/Program.cs
@@ -38,7 +38,7 @@ namespace ColorzCore
             "   Enable debug mode. Not recommended for end users."};
         private static string helpstring = System.Linq.Enumerable.Aggregate(helpstringarr, (String a, String b) => { return a + '\n' + b; }) + '\n';
 
-        static void Main(string[] args)
+        static int Main(string[] args)
         {
             EAOptions options = new EAOptions();
             Stream inStream = Console.OpenStandardInput();
@@ -94,19 +94,24 @@ namespace ColorzCore
                                 options.nomess = true;
                                 options.nowarn = true;
                                 break;
+
+                            case "-nocash-sym":
+                                options.nocashSym = true;
+                                break;
+
                             case "h":
                             case "-help":
                                 Console.Out.WriteLine(helpstring);
-                                return;
+                                return 0;
                             default:
                                 Console.Error.WriteLine("Unrecognized flag: " + flag[0]);
-                                return;
+                                return 1;
                         }
                     }
                     catch(IOException e)
                     {
                         Console.Error.WriteLine("Exception: " + e.Message);
-                        return;
+                        return 1;
                     }
                 }
             }
@@ -114,32 +119,35 @@ namespace ColorzCore
             if (args.Length < 2)
             {
                 Console.WriteLine("Required parameters missing.");
-                return;
+                return 1;
             }
             if (args[0] != "A")
             {
                 Console.WriteLine("Only assembly is supported currently.");
-                return;
+                return 1;
             }
             string game = args[1];
             if (outStream == null)
             {
                 Console.Error.WriteLine("No output specified for assembly.");
-                return;
+                return 1;
             }
             if (rawsFolder.IsNothing)
             {
                 Console.Error.WriteLine("Couldn't find raws folder");
-                return;
+                return 1;
             }
             //FirstPass(Tokenizer.Tokenize(inputStream));
 
             EAInterpreter myInterpreter = new EAInterpreter(game, rawsFolder.FromJust, rawsExtension, inStream, inFileName, outStream, errorStream, options);
-            myInterpreter.Interpret();
+
+            bool success = myInterpreter.Interpret();
 
             inStream.Close();
             outStream.Close();
-            errorStream.Close();            
+            errorStream.Close();
+
+            return success ? 0 : 1;
         }
     }
 }

--- a/ColorzCore/Program.cs
+++ b/ColorzCore/Program.cs
@@ -43,6 +43,7 @@ namespace ColorzCore
             EAOptions options = new EAOptions();
             Stream inStream = Console.OpenStandardInput();
             FileStream outStream = null;
+            string outFileName = "none";
             TextWriter errorStream = Console.Error;
             Maybe<string> rawsFolder = IOUtility.FindDirectory("Language Raws");
             string rawsExtension = ".txt";
@@ -69,7 +70,8 @@ namespace ColorzCore
                                 rawsExtension = flag[1];
                                 break;
                             case "output":
-                                outStream = File.Open(flag[1], FileMode.Open, FileAccess.ReadWrite); //TODO: Handle file not found exceptions
+                                outFileName = flag[1];
+                                outStream = File.Open(outFileName, FileMode.Open, FileAccess.ReadWrite); //TODO: Handle file not found exceptions
                                 break;
                             case "input":
                                 inFileName = flag[1];
@@ -142,6 +144,17 @@ namespace ColorzCore
             EAInterpreter myInterpreter = new EAInterpreter(game, rawsFolder.FromJust, rawsExtension, inStream, inFileName, outStream, errorStream, options);
 
             bool success = myInterpreter.Interpret();
+
+            if (success && options.nocashSym)
+            {
+                using (var output = File.CreateText(Path.ChangeExtension(outFileName, "sym")))
+                {
+                    if (!(success = myInterpreter.WriteNocashSymbols(output)))
+                    {
+                        Console.Error.WriteLine("Error trying to write no$gba symbol file.");
+                    }
+                }
+            }
 
             inStream.Close();
             outStream.Close();


### PR DESCRIPTION
Even if @Crazycolorz5 said he'd do it, he was probably too busy playing smash so I did it instead

Handles part of #8, closes #29. Tested on VBA-BT and works.

The option you need to pass it to generate a no$ sym file is, as suggested in the issue, `--nocash-sym` (and it generates a file with name based on output file name, as that's how no$ knows to read it).

Because no$ sym files are simple af, the user can just `type vanilla.sym >> hack.sym` (or any other shell's equivalent) to get a "full" sym file that contains symbol definitions for both the vanilla game and the hacked stuff!

![image](https://user-images.githubusercontent.com/4533018/50589391-bcf39f80-0e86-11e9-962f-b0e2d6794721.png)
