### PR TITLE
Add IsDefined builtin and AddToPool/#pool

### DIFF
--- a/ColorzCore/ColorzCore.csproj
+++ b/ColorzCore/ColorzCore.csproj
@@ -109,6 +109,8 @@
     <Compile Include="IO\Log.cs" />
     <Compile Include="IO\IncludeFileSearcher.cs" />
     <Compile Include="Parser\Macros\IsDefined.cs" />
+    <Compile Include="Parser\Macros\AddToPool.cs" />
+    <Compile Include="Preprocessor\Directives\PoolDirective.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/ColorzCore/ColorzCore.csproj
+++ b/ColorzCore/ColorzCore.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Parser\Macros\IsDefined.cs" />
     <Compile Include="Parser\Macros\AddToPool.cs" />
     <Compile Include="Preprocessor\Directives\PoolDirective.cs" />
+    <Compile Include="Parser\Pool.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/ColorzCore/ColorzCore.csproj
+++ b/ColorzCore/ColorzCore.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -108,6 +108,7 @@
     <Compile Include="Raws\Raw.cs" />
     <Compile Include="IO\Log.cs" />
     <Compile Include="IO\IncludeFileSearcher.cs" />
+    <Compile Include="Parser\Macros\IsDefined.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/ColorzCore/EAInterpreter.cs
+++ b/ColorzCore/EAInterpreter.cs
@@ -3,6 +3,7 @@ using ColorzCore.IO;
 using ColorzCore.Lexer;
 using ColorzCore.Parser;
 using ColorzCore.Parser.AST;
+using ColorzCore.Parser.Macros;
 using ColorzCore.Raws;
 using System;
 using System.Collections.Generic;
@@ -100,7 +101,14 @@ namespace ColorzCore
 
             foreach (Token errCause in undefinedIds)
             {
-                myParser.Error(errCause.Location, "Undefined identifier: " + errCause.Content);
+                if (errCause.Content.StartsWith(AddToPool.pooledLabelPrefix, StringComparison.Ordinal))
+                {
+                    myParser.Error(errCause.Location, "Unpooled data (forgot #pool?)");
+                }
+                else
+                {
+                    myParser.Error(errCause.Location, "Undefined identifier: " + errCause.Content);
+                }
             }
 
             /* Last step: assembly */

--- a/ColorzCore/EAInterpreter.cs
+++ b/ColorzCore/EAInterpreter.cs
@@ -3,7 +3,6 @@ using ColorzCore.IO;
 using ColorzCore.Lexer;
 using ColorzCore.Parser;
 using ColorzCore.Parser.AST;
-using ColorzCore.Parser.Macros;
 using ColorzCore.Raws;
 using System;
 using System.Collections.Generic;
@@ -101,7 +100,7 @@ namespace ColorzCore
 
             foreach (Token errCause in undefinedIds)
             {
-                if (errCause.Content.StartsWith(AddToPool.pooledLabelPrefix, StringComparison.Ordinal))
+                if (errCause.Content.StartsWith(Pool.pooledLabelPrefix, StringComparison.Ordinal))
                 {
                     myParser.Error(errCause.Location, "Unpooled data (forgot #pool?)");
                 }

--- a/ColorzCore/Parser/AST/MacroInvocationNode.cs
+++ b/ColorzCore/Parser/AST/MacroInvocationNode.cs
@@ -19,15 +19,17 @@ namespace ColorzCore.Parser.AST
             }
         }
 
-        private EAParser p;
-        private Token invokeToken;
+        private readonly EAParser p;
+        private readonly Token invokeToken;
+        private readonly ImmutableStack<Closure> scope;
         public IList<IList<Token>> Parameters { get; }
 
-        public MacroInvocationNode(EAParser p, Token invokeTok, IList<IList<Token>> parameters)
+        public MacroInvocationNode(EAParser p, Token invokeTok, IList<IList<Token>> parameters, ImmutableStack<Closure> scopes)
         {
             this.p = p;
             this.invokeToken = invokeTok;
             this.Parameters = parameters;
+            this.scope = scopes;
         }
 
         public ParamType Type => ParamType.MACRO;
@@ -52,7 +54,7 @@ namespace ColorzCore.Parser.AST
 
         public IEnumerable<Token> ExpandMacro()
         {
-            return p.Macros.GetMacro(invokeToken.Content, Parameters.Count).ApplyMacro(invokeToken, Parameters);
+            return p.Macros.GetMacro(invokeToken.Content, Parameters.Count).ApplyMacro(invokeToken, Parameters, scope);
         }
 
         public Either<int, string> TryEvaluate()

--- a/ColorzCore/Parser/EAParser.cs
+++ b/ColorzCore/Parser/EAParser.cs
@@ -47,7 +47,6 @@ namespace ColorzCore.Parser
         public ImmutableStack<bool> Inclusion { get; set; }
 
         public List<List<Token>> PooledLines { get; private set; }
-        private long poolLabelCounter;
 
         private readonly DirectiveHandler directiveHandler;
 
@@ -84,7 +83,6 @@ namespace ColorzCore.Parser
             this.directiveHandler = directiveHandler;
 
             PooledLines = new List<List<Token>>();
-            poolLabelCounter = 0;
         }
 
         public bool IsReservedName(string name)
@@ -765,12 +763,6 @@ namespace ColorzCore.Parser
             }
 
             return ret;
-        }
-
-        public string MakePoolLabelName()
-        {
-            // The presence of $ in the label name guarantees that it can't be a user label
-            return string.Format("__POOLED${0}", poolLabelCounter++);
         }
 
         public void Message(Location? loc, string message)

--- a/ColorzCore/Parser/EAParser.cs
+++ b/ColorzCore/Parser/EAParser.cs
@@ -46,6 +46,9 @@ namespace ColorzCore.Parser
         }
         public ImmutableStack<bool> Inclusion { get; set; }
 
+        public List<List<Token>> PooledLines { get; private set; }
+        private long poolLabelCounter;
+
         private readonly DirectiveHandler directiveHandler;
 
         private Stack<Tuple<int, bool>> pastOffsets; // currentOffset, offsetInitialized
@@ -79,6 +82,9 @@ namespace ColorzCore.Parser
             Definitions = new Dictionary<string, Definition>();
             Inclusion = ImmutableStack<bool>.Nil;
             this.directiveHandler = directiveHandler;
+
+            PooledLines = new List<List<Token>>();
+            poolLabelCounter = 0;
         }
 
         public bool IsReservedName(string name)
@@ -759,6 +765,12 @@ namespace ColorzCore.Parser
             }
 
             return ret;
+        }
+
+        public string MakePoolLabelName()
+        {
+            // The presence of $ in the label name guarantees that it can't be a user label
+            return string.Format("__POOLED${0}", poolLabelCounter++);
         }
 
         public void Message(Location? loc, string message)

--- a/ColorzCore/Parser/EAParser.cs
+++ b/ColorzCore/Parser/EAParser.cs
@@ -46,7 +46,7 @@ namespace ColorzCore.Parser
         }
         public ImmutableStack<bool> Inclusion { get; set; }
 
-        public List<List<Token>> PooledLines { get; private set; }
+        public Pool Pool { get; private set; }
 
         private readonly DirectiveHandler directiveHandler;
 
@@ -82,7 +82,7 @@ namespace ColorzCore.Parser
             Inclusion = ImmutableStack<bool>.Nil;
             this.directiveHandler = directiveHandler;
 
-            PooledLines = new List<List<Token>>();
+            Pool = new Pool();
         }
 
         public bool IsReservedName(string name)
@@ -139,7 +139,7 @@ namespace ColorzCore.Parser
         }
         private Maybe<StatementNode> ParseStatement(MergeableGenerator<Token> tokens, ImmutableStack<Closure> scopes)
         {
-            while (ExpandIdentifier(tokens)) ;
+            while (ExpandIdentifier(tokens, scopes)) { }
             head = tokens.Current;
             tokens.MoveNext();
             //TODO: Replace with real raw information, and error if not valid.
@@ -383,7 +383,7 @@ namespace ColorzCore.Parser
                     return new Just<IParamNode>(new StringNode(head));
                 case TokenType.MAYBE_MACRO:
                     //TODO: Move this and the one in ExpandId to a separate ParseMacroNode that may return an Invocation.
-                    if (expandDefs && ExpandIdentifier(tokens))
+                    if (expandDefs && ExpandIdentifier(tokens, scopes))
                     {
                         return ParseParam(tokens, scopes);
                     }
@@ -392,10 +392,10 @@ namespace ColorzCore.Parser
                         tokens.MoveNext();
                         IList<IList<Token>> param = ParseMacroParamList(tokens);
                         //TODO: Smart errors if trying to redefine a macro with the same num of params.
-                        return new Just<IParamNode>(new MacroInvocationNode(this, head, param));
+                        return new Just<IParamNode>(new MacroInvocationNode(this, head, param, scopes));
                     }
                 case TokenType.IDENTIFIER:
-                    if (expandDefs && Definitions.ContainsKey(head.Content) && ExpandIdentifier(tokens))
+                    if (expandDefs && Definitions.ContainsKey(head.Content) && ExpandIdentifier(tokens, scopes))
                         return ParseParam(tokens, scopes, expandDefs);
                     else
                         return ParseAtom(tokens,scopes,expandDefs).Fmap((IAtomNode x) => (IParamNode)x);
@@ -527,7 +527,7 @@ namespace ColorzCore.Parser
                 {
                     if (lookAhead.Type == TokenType.IDENTIFIER)
                     {
-                        if (expandDefs && ExpandIdentifier(tokens))
+                        if (expandDefs && ExpandIdentifier(tokens, scopes))
                             continue;
                         if (lookAhead.Content.ToUpper() == "CURRENTOFFSET")
                             grammarSymbols.Push(new Left<IAtomNode, Token>(new NumberNode(lookAhead, CurrentOffset)));
@@ -536,7 +536,7 @@ namespace ColorzCore.Parser
                     }
                     else if (lookAhead.Type == TokenType.MAYBE_MACRO)
                     {
-                        ExpandIdentifier(tokens);
+                        ExpandIdentifier(tokens, scopes);
                         continue;
                     }
                     else if (lookAhead.Type == TokenType.NUMBER)
@@ -640,7 +640,7 @@ namespace ColorzCore.Parser
                 {
                     case TokenType.IDENTIFIER:
                     case TokenType.MAYBE_MACRO:
-                        if (ExpandIdentifier(tokens))
+                        if (ExpandIdentifier(tokens, scopes))
                         {
                             return ParseLine(tokens, scopes);
                         }
@@ -728,7 +728,7 @@ namespace ColorzCore.Parser
          *   Postcondition: tokens.Current is fully reduced (i.e. not a macro, and not a definition)
          *   Returns: true iff tokens was actually expanded.
          */
-        public bool ExpandIdentifier(MergeableGenerator<Token> tokens)
+        public bool ExpandIdentifier(MergeableGenerator<Token> tokens, ImmutableStack<Closure> scopes)
         {
             bool ret = false;
             //Macros and Definitions.
@@ -739,7 +739,7 @@ namespace ColorzCore.Parser
                 IList<IList<Token>> parameters = ParseMacroParamList(tokens);
                 if (Macros.HasMacro(head.Content, parameters.Count))
                 {
-                    tokens.PrependEnumerator(Macros.GetMacro(head.Content, parameters.Count).ApplyMacro(head, parameters).GetEnumerator());
+                    tokens.PrependEnumerator(Macros.GetMacro(head.Content, parameters.Count).ApplyMacro(head, parameters, scopes).GetEnumerator());
                 }
                 else
                 {

--- a/ColorzCore/Parser/Macros/AddToPool.cs
+++ b/ColorzCore/Parser/Macros/AddToPool.cs
@@ -12,6 +12,8 @@ namespace ColorzCore.Parser.Macros
          * AddToPool(tokens..., alignment): adds token to pool and make sure pooled tokens are aligned given alignment        
          */
 
+        public static readonly string pooledLabelPrefix = "__POOLED$";
+
         public EAParser ParentParser { get; private set; }
 
         private long poolLabelCounter;
@@ -59,7 +61,7 @@ namespace ColorzCore.Parser.Macros
         protected string MakePoolLabelName()
         {
             // The presence of $ in the label name guarantees that it can't be a user label
-            return string.Format("__POOLED${0}", poolLabelCounter++);
+            return string.Format("{0}{1}", pooledLabelPrefix, poolLabelCounter++);
         }
     }
 }

--- a/ColorzCore/Parser/Macros/AddToPool.cs
+++ b/ColorzCore/Parser/Macros/AddToPool.cs
@@ -14,16 +14,19 @@ namespace ColorzCore.Parser.Macros
 
         public EAParser ParentParser { get; private set; }
 
+        private long poolLabelCounter;
+
         public AddToPool(EAParser parent)
         {
             ParentParser = parent;
+            poolLabelCounter = 0;
         }
 
         public override IEnumerable<Token> ApplyMacro(Token head, IList<IList<Token>> parameters)
         {
             List<Token> line = new List<Token>(6 + parameters[0].Count);
 
-            string labelName = ParentParser.MakePoolLabelName();
+            string labelName = MakePoolLabelName();
 
             if (parameters.Count == 2)
             {
@@ -51,6 +54,12 @@ namespace ColorzCore.Parser.Macros
         public override bool ValidNumParams(int num)
         {
             return num == 1 || num == 2;
+        }
+
+        protected string MakePoolLabelName()
+        {
+            // The presence of $ in the label name guarantees that it can't be a user label
+            return string.Format("__POOLED${0}", poolLabelCounter++);
         }
     }
 }

--- a/ColorzCore/Parser/Macros/AddToPool.cs
+++ b/ColorzCore/Parser/Macros/AddToPool.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using ColorzCore.Lexer;
+
+namespace ColorzCore.Parser.Macros
+{
+    class AddToPool : BuiltInMacro
+    {
+        /*
+         * Macro Usage:
+         * AddToPool(tokens...): adds token to pool, and expands to label name referring to those tokens
+         * AddToPool(tokens..., alignment): adds token to pool and make sure pooled tokens are aligned given alignment        
+         */
+
+        public EAParser ParentParser { get; private set; }
+
+        public AddToPool(EAParser parent)
+        {
+            ParentParser = parent;
+        }
+
+        public override IEnumerable<Token> ApplyMacro(Token head, IList<IList<Token>> parameters)
+        {
+            List<Token> line = new List<Token>(6 + parameters[0].Count);
+
+            string labelName = ParentParser.MakePoolLabelName();
+
+            if (parameters.Count == 2)
+            {
+                // Add Alignment directive 
+
+                line.Add(new Token(TokenType.IDENTIFIER, head.Location, "ALIGN"));
+                line.Add(parameters[1][0]);
+                line.Add(new Token(TokenType.SEMICOLON, head.Location, ";"));
+            }
+
+            // TODO: Make label declaration global (when this feature gets implemented)
+            // This way the name will be available as long as it is pooled (reguardless of pool scope)
+
+            line.Add(new Token(TokenType.IDENTIFIER, head.Location, labelName));
+            line.Add(new Token(TokenType.COLON, head.Location, ":"));
+
+            line.AddRange(parameters[0]);
+            line.Add(new Token(TokenType.NEWLINE, head.Location, "\n"));
+
+            ParentParser.PooledLines.Add(line);
+
+            yield return new Token(TokenType.IDENTIFIER, head.Location, labelName);
+        }
+
+        public override bool ValidNumParams(int num)
+        {
+            return num == 1 || num == 2;
+        }
+    }
+}

--- a/ColorzCore/Parser/Macros/BuiltInMacro.cs
+++ b/ColorzCore/Parser/Macros/BuiltInMacro.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ColorzCore.DataTypes;
 using ColorzCore.Lexer;
 
 namespace ColorzCore.Parser.Macros
@@ -10,6 +11,6 @@ namespace ColorzCore.Parser.Macros
     abstract class BuiltInMacro : IMacro
     {
         public abstract bool ValidNumParams(int num);
-        public abstract IEnumerable<Token> ApplyMacro(Token head, IList<IList<Token>> parameters);
+        public abstract IEnumerable<Token> ApplyMacro(Token head, IList<IList<Token>> parameters, ImmutableStack<Closure> scopes);
     }
 }

--- a/ColorzCore/Parser/Macros/IMacro.cs
+++ b/ColorzCore/Parser/Macros/IMacro.cs
@@ -1,4 +1,5 @@
-﻿using ColorzCore.Lexer;
+﻿using ColorzCore.DataTypes;
+using ColorzCore.Lexer;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,6 +10,6 @@ namespace ColorzCore.Parser.Macros
 {
     public interface IMacro
     {
-        IEnumerable<Token> ApplyMacro(Token head, IList<IList<Token>> parameters);
+        IEnumerable<Token> ApplyMacro(Token head, IList<IList<Token>> parameters, ImmutableStack<Closure> scopes);
     }
 }

--- a/ColorzCore/Parser/Macros/IsDefined.cs
+++ b/ColorzCore/Parser/Macros/IsDefined.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using ColorzCore.Lexer;
+
+namespace ColorzCore.Parser.Macros
+{
+    class IsDefined : BuiltInMacro
+    {
+        public EAParser ParentParser { get; private set; }
+
+        public IsDefined(EAParser parent)
+        {
+            ParentParser = parent;
+        }
+
+        public override IEnumerable<Token> ApplyMacro(Token head, IList<IList<Token>> parameters)
+        {
+            if (parameters[0].Count != 1)
+            {
+                // TODO: err somehow
+                yield return MakeFalseToken(head.Location);
+            }
+            else
+            {
+                Token token = parameters[0][0];
+
+                if ((token.Type == TokenType.IDENTIFIER) && IsReallyDefined(token.Content))
+                {
+                    yield return MakeTrueToken(head.Location);
+                }
+                else
+                {
+                    yield return MakeFalseToken(head.Location);
+                }
+            }
+        }
+
+        public override bool ValidNumParams(int num)
+        {
+            return num == 1;
+        }
+
+        protected bool IsReallyDefined(string name)
+        {
+            return ParentParser.Definitions.ContainsKey(name) || ParentParser.Macros.ContainsName(name);
+        }
+
+        protected static Token MakeTrueToken(DataTypes.Location location)
+        {
+            return new Token(TokenType.NUMBER, location, "1");
+        }
+
+        protected static Token MakeFalseToken(DataTypes.Location location)
+        {
+            return new Token(TokenType.NUMBER, location, "0");
+        }
+    }
+}

--- a/ColorzCore/Parser/Macros/IsDefined.cs
+++ b/ColorzCore/Parser/Macros/IsDefined.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using ColorzCore.DataTypes;
 using ColorzCore.Lexer;
 
 namespace ColorzCore.Parser.Macros
@@ -13,7 +14,7 @@ namespace ColorzCore.Parser.Macros
             ParentParser = parent;
         }
 
-        public override IEnumerable<Token> ApplyMacro(Token head, IList<IList<Token>> parameters)
+        public override IEnumerable<Token> ApplyMacro(Token head, IList<IList<Token>> parameters, ImmutableStack<Closure> scopes)
         {
             if (parameters[0].Count != 1)
             {

--- a/ColorzCore/Parser/Macros/Macro.cs
+++ b/ColorzCore/Parser/Macros/Macro.cs
@@ -1,4 +1,5 @@
-﻿using ColorzCore.Lexer;
+﻿using ColorzCore.DataTypes;
+using ColorzCore.Lexer;
 using ColorzCore.Parser.AST;
 using System;
 using System.Collections.Generic;
@@ -26,7 +27,7 @@ namespace ColorzCore.Parser.Macros
         /***
          *   Precondition: parameters.Count = max(keys(idToParamNum))
          */
-        public IEnumerable<Token> ApplyMacro(Token head, IList<IList<Token>> parameters)
+        public IEnumerable<Token> ApplyMacro(Token head, IList<IList<Token>> parameters, ImmutableStack<Closure> scopes)
         {
             foreach(Token t in body)
             {

--- a/ColorzCore/Parser/Macros/MacroCollection.cs
+++ b/ColorzCore/Parser/Macros/MacroCollection.cs
@@ -17,7 +17,11 @@ namespace ColorzCore.Parser.Macros
         {
             Macros = new Dictionary<string, Dictionary<int, IMacro>>();
             Parent = parent;
-            BuiltInMacros = new Dictionary<string, BuiltInMacro> { { "String", String.Instance } };
+
+            BuiltInMacros = new Dictionary<string, BuiltInMacro> {
+                { "String", String.Instance },
+                { "IsDefined", new IsDefined(parent) },
+            };
         }
 
         public bool HasMacro(string name, int paramNum)

--- a/ColorzCore/Parser/Macros/MacroCollection.cs
+++ b/ColorzCore/Parser/Macros/MacroCollection.cs
@@ -19,7 +19,7 @@ namespace ColorzCore.Parser.Macros
             Parent = parent;
 
             BuiltInMacros = new Dictionary<string, BuiltInMacro> {
-                { "String", String.Instance },
+                { "String", new String() },
                 { "IsDefined", new IsDefined(parent) },
             };
         }

--- a/ColorzCore/Parser/Macros/MacroCollection.cs
+++ b/ColorzCore/Parser/Macros/MacroCollection.cs
@@ -21,6 +21,7 @@ namespace ColorzCore.Parser.Macros
             BuiltInMacros = new Dictionary<string, BuiltInMacro> {
                 { "String", new String() },
                 { "IsDefined", new IsDefined(parent) },
+                { "AddToPool", new AddToPool(parent) },
             };
         }
 

--- a/ColorzCore/Parser/Macros/String.cs
+++ b/ColorzCore/Parser/Macros/String.cs
@@ -1,4 +1,5 @@
-﻿using ColorzCore.Lexer;
+﻿using ColorzCore.DataTypes;
+using ColorzCore.Lexer;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,7 +10,7 @@ namespace ColorzCore.Parser.Macros
 {
     class String : BuiltInMacro
     {
-        public override IEnumerable<Token> ApplyMacro(Token head, IList<IList<Token>> parameters)
+        public override IEnumerable<Token> ApplyMacro(Token head, IList<IList<Token>> parameters, ImmutableStack<Closure> scopes)
         {
             yield return new Token(TokenType.IDENTIFIER, head.Location, "BYTE");
             foreach (byte num in Encoding.ASCII.GetBytes(parameters[0][0].Content.ToCharArray())) //TODO: Errors if not adherent?

--- a/ColorzCore/Parser/Macros/String.cs
+++ b/ColorzCore/Parser/Macros/String.cs
@@ -9,12 +9,6 @@ namespace ColorzCore.Parser.Macros
 {
     class String : BuiltInMacro
     {
-        private static String instance = new String();
-
-        public static String Instance { get { return instance; } }
-
-        private String() { }
-
         public override IEnumerable<Token> ApplyMacro(Token head, IList<IList<Token>> parameters)
         {
             yield return new Token(TokenType.IDENTIFIER, head.Location, "BYTE");

--- a/ColorzCore/Parser/Pool.cs
+++ b/ColorzCore/Parser/Pool.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using ColorzCore.DataTypes;
+using ColorzCore.Lexer;
+
+namespace ColorzCore.Parser
+{
+    class Pool
+    {
+        public struct PooledLine
+        {
+            public ImmutableStack<Closure> Scope { get; private set; }
+            public List<Token> Tokens { get; private set; }
+
+            public PooledLine(ImmutableStack<Closure> scope, List<Token> tokens)
+            {
+                Scope = scope;
+                Tokens = tokens;
+            }
+        }
+
+        public static readonly string pooledLabelPrefix = "__POOLED$";
+
+        public List<PooledLine> Lines { get; private set; }
+
+        private long poolLabelCounter;
+
+        public Pool()
+        {
+            Lines = new List<PooledLine>();
+            poolLabelCounter = 0;
+        }
+
+        public string MakePoolLabelName()
+        {
+            // The presence of $ in the label name guarantees that it can't be a user label
+            return string.Format("{0}{1}", pooledLabelPrefix, poolLabelCounter++);
+        }
+    }
+}

--- a/ColorzCore/Preprocessor/DirectiveHandler.cs
+++ b/ColorzCore/Preprocessor/DirectiveHandler.cs
@@ -29,8 +29,9 @@ namespace ColorzCore.Preprocessor
                 { "ifndef", new IfNotDefinedDirective() },
                 { "else", new ElseDirective() },
                 { "endif", new EndIfDirective() },
-                { "define", new DefineDirective() }, //TODO: pool
-                { "undef", new UndefineDirective() }
+                { "define", new DefineDirective() },
+                { "pool", new PoolDirective() },
+                { "undef", new UndefineDirective() },
             };
         }
 

--- a/ColorzCore/Preprocessor/Directives/DefineDirective.cs
+++ b/ColorzCore/Preprocessor/Directives/DefineDirective.cs
@@ -148,7 +148,7 @@ namespace ColorzCore.Preprocessor.Directives
                         IList<IList<Token>> param = p.ParseMacroParamList(new MergeableGenerator<Token>(tokens)); //TODO: I don't like wrapping this in a mergeable generator..... Maybe interface the original better?
                         if (!seenMacros.Contains(new Tuple<string, int>(current.Content, param.Count)) && p.Macros.HasMacro(current.Content, param.Count))
                         {
-                            foreach(Token t in  p.Macros.GetMacro(current.Content, param.Count).ApplyMacro(current, param))
+                            foreach(Token t in  p.Macros.GetMacro(current.Content, param.Count).ApplyMacro(current, param, p.GlobalScope))
                             {
                                 yield return t; 
                             }

--- a/ColorzCore/Preprocessor/Directives/PoolDirective.cs
+++ b/ColorzCore/Preprocessor/Directives/PoolDirective.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using ColorzCore.DataTypes;
+using ColorzCore.Lexer;
+using ColorzCore.Parser;
+using ColorzCore.Parser.AST;
+
+namespace ColorzCore.Preprocessor.Directives
+{
+    class PoolDirective : IDirective
+    {
+        public int MinParams => 0;
+        public int? MaxParams => 0;
+        public bool RequireInclusion => true;
+
+        public Maybe<ILineNode> Execute(EAParser p, Token self, IList<IParamNode> parameters, MergeableGenerator<Token> tokens)
+        {
+            foreach (List<Token> line in p.PooledLines)
+            {
+                tokens.PrependEnumerator(line.GetEnumerator());
+            }
+
+            p.PooledLines.Clear();
+
+            return new Nothing<ILineNode>();
+        }
+    }
+}

--- a/ColorzCore/Preprocessor/Directives/PoolDirective.cs
+++ b/ColorzCore/Preprocessor/Directives/PoolDirective.cs
@@ -17,19 +17,19 @@ namespace ColorzCore.Preprocessor.Directives
         {
             BlockNode result = new BlockNode();
 
-            foreach (List<Token> line in p.PooledLines)
+            foreach (Pool.PooledLine line in p.Pool.Lines)
             {
-                MergeableGenerator<Token> tempGenerator = new MergeableGenerator<Token>(line);
+                MergeableGenerator<Token> tempGenerator = new MergeableGenerator<Token>(line.Tokens);
                 tempGenerator.MoveNext();
 
                 while (!tempGenerator.EOS)
                 {
-                    p.ParseLine(tempGenerator, p.GlobalScope).IfJust(
+                    p.ParseLine(tempGenerator, line.Scope).IfJust(
                         (lineNode) => result.Children.Add(lineNode));
                 }
             }
 
-            p.PooledLines.Clear();
+            p.Pool.Lines.Clear();
 
             return new Just<ILineNode>(result);
         }

--- a/ColorzCore/Preprocessor/Directives/PoolDirective.cs
+++ b/ColorzCore/Preprocessor/Directives/PoolDirective.cs
@@ -15,14 +15,23 @@ namespace ColorzCore.Preprocessor.Directives
 
         public Maybe<ILineNode> Execute(EAParser p, Token self, IList<IParamNode> parameters, MergeableGenerator<Token> tokens)
         {
+            BlockNode result = new BlockNode();
+
             foreach (List<Token> line in p.PooledLines)
             {
-                tokens.PrependEnumerator(line.GetEnumerator());
+                MergeableGenerator<Token> tempGenerator = new MergeableGenerator<Token>(line);
+                tempGenerator.MoveNext();
+
+                while (!tempGenerator.EOS)
+                {
+                    p.ParseLine(tempGenerator, p.GlobalScope).IfJust(
+                        (lineNode) => result.Children.Add(lineNode));
+                }
             }
 
             p.PooledLines.Clear();
 
-            return new Nothing<ILineNode>();
+            return new Just<ILineNode>(result);
         }
     }
 }

--- a/ColorzCore/Preprocessor/Directives/PoolDirective.cs
+++ b/ColorzCore/Preprocessor/Directives/PoolDirective.cs
@@ -17,8 +17,13 @@ namespace ColorzCore.Preprocessor.Directives
         {
             BlockNode result = new BlockNode();
 
-            foreach (Pool.PooledLine line in p.Pool.Lines)
+            // Iterating indices (and not values via foreach)
+            // to avoid crashes occuring with AddToPool within AddToPool
+
+            for (int i = 0; i < p.Pool.Lines.Count; ++i)
             {
+                Pool.PooledLine line = p.Pool.Lines[i];
+
                 MergeableGenerator<Token> tempGenerator = new MergeableGenerator<Token>(line.Tokens);
                 tempGenerator.MoveNext();
 


### PR DESCRIPTION
They work essentially the same way they did in legacy EA.

- `IsDefined(Name)` expands to `1` if a definition or macro (~~why are those different things~~) of given name exists, expands to `0` otherwise.
- `AddToPool(tokens...)` expands to the name of a label referring to data described by the listed tokens (that would be pooled by a subsequent `#pool` directive).
- `AddToPool(tokens..., Alignment)` is the same as above, with the additional guarantee that the pooled data will be aligned with requested Alignment. This one is isn't in legacy EA.

~~Pool stuff is still a bit jank as pool labels are still affected by scope shenanigans (so in order for all of this to work, the `#pool` directive needs to be in a label scope that is visible to the `AddToPool` macros). We could make this slightly better if #37 gets implemented.~~ Dumped pooled data is now parsed as if label scope is the same as the one from the `AddToPool` expression.

Pool labels are internally under the form `__POOLED$<number>`. They have a `$` character in them to guarantee no user label can conflict with pool labels.

(I need to figure out how I can expand full expressions within builtin macros so I can implement more of the old stuff (Stuff like `Signum`, `Switch`, and maybe a variant of `IsDefined` that takes a second integer parameter that checks for a macro with that parameter count specifically)).