### PR TITLE
Maybe fix lowercase code names on some systems

### DIFF
--- a/ColorzCore/Parser/EAParser.cs
+++ b/ColorzCore/Parser/EAParser.cs
@@ -156,9 +156,11 @@ namespace ColorzCore.Parser
                 tokens.MoveNext();
             }
 
-            if (SpecialCodes.Contains(head.Content.ToUpper()))
+            string upperCodeIdentifier = head.Content.ToUpperInvariant();
+
+            if (SpecialCodes.Contains(upperCodeIdentifier))
             {
-                switch(head.Content.ToUpper())
+                switch (upperCodeIdentifier)
                 {
                     case "ORG":
                         if (parameters.Count != 1)
@@ -276,10 +278,10 @@ namespace ColorzCore.Parser
                 }
                 return new Nothing<StatementNode>();
             }
-            else if (Raws.ContainsKey(head.Content.ToUpper()))
+            else if (Raws.ContainsKey(upperCodeIdentifier))
             {
                 //TODO: Check for matches. Currently should type error.
-                foreach(Raw r in Raws[head.Content.ToUpper()])
+                foreach(Raw r in Raws[upperCodeIdentifier])
                 {
                     if (r.Fits(parameters))
                     {

--- a/ColorzCore/Raws/Raw.cs
+++ b/ColorzCore/Raws/Raw.cs
@@ -121,7 +121,7 @@ namespace ColorzCore.Raws
             if (Char.IsWhiteSpace(rawLine[0]))
                 throw new RawParseException("Raw not at start of line.", rawLine);
             string[] parts = rawLine.Split(new char[1] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-            string name = parts[0].Trim().ToUpper(); //Note all raws implicitly have all uppercase names -- this is to allow for case-insensitive comparison down the line. TODO: Make case sensitivity a requirement?
+            string name = parts[0].Trim().ToUpperInvariant(); //Note all raws implicitly have all uppercase names -- this is to allow for case-insensitive comparison down the line. TODO: Make case sensitivity a requirement?
             string code = parts[1].Trim();
             string length = parts[2].Trim();
             string flags = parts.Length == 4 ? parts[3].Trim() : "";


### PR DESCRIPTION
I got reports of lowercase code identifiers causing errors (while it shouldn't), but I couldn't reproduce the issue. I figured it may have been because of the culture-aware (whatever that means) nature of the string.ToUpper method that is used for converting code names, so I changed it to use ToUpperInvariant instead (which is apparently faster anyway).

[The problematic case](https://github.com/FireEmblemUniverse/SkillSystem_FE8/blob/ac2d078b00d4e46401b8008ad3f5a4cbbdaa983b/Engine%20Hacks/FE8-Item%20Range%20Fix/ItemTargeting/SpecialRanges.event#L2) (`poin` vs `POIN`).