### PR TITLE
fix bug with predefinitions

### DIFF
--- a/ColorzCore/EADriver.cs
+++ b/ColorzCore/EADriver.cs
@@ -145,10 +145,10 @@ namespace ColorzCore
 
             ExecTimer.Timer.AddTimingPoint(ExecTimer.KEY_GENERIC);
 
-            foreach ((string name, string body) in EAOptions.PreDefintions)
+            foreach ((string name, string body) in EAOptions.PreDefinitions)
             {
                 Location location = new Location("CMD", 0, 1);
-                myParser.ParseAll(tokenizer.TokenizePhrase($"#define {name} \"{body}\"", location));
+                myParser.ParseAll(tokenizer.TokenizePhrase($"#define {name} \"{body}\"\n", location));
             }
 
             myParser.ParseAll(tokenizer.Tokenize(sin, iFile));

--- a/ColorzCore/EAOptions.cs
+++ b/ColorzCore/EAOptions.cs
@@ -71,7 +71,7 @@ namespace ColorzCore
 
         public static List<string> IncludePaths { get; } = new List<string>();
         public static List<string> ToolsPaths { get; } = new List<string>();
-        public static List<(string, string)> PreDefintions { get; } = new List<(string, string)>();
+        public static List<(string, string)> PreDefinitions { get; } = new List<(string, string)>();
 
         public static Warnings EnabledWarnings { get; set; } = Warnings.All;
 

--- a/ColorzCore/Program.cs
+++ b/ColorzCore/Program.cs
@@ -226,7 +226,7 @@ namespace ColorzCore
                             try
                             {
                                 string[] def_args = flag[1].Split(new char[] { '=' }, 2);
-                                EAOptions.PreDefintions.Add((def_args[0], def_args[1]));
+                                EAOptions.PreDefinitions.Add((def_args[0], def_args[1]));
                             }
                             catch (IndexOutOfRangeException)
                             {


### PR DESCRIPTION
A missing `\n` when processing command-line definitions caused the parser to hang.

Also, `Defintions` -> `Definitions`.